### PR TITLE
Add group and description to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@
  */
 
 task build() {
+  group = 'Build'
+  description = 'Builds all submodules'
+
   doLast {
     exec {
       executable "./build.sh"
@@ -14,6 +17,9 @@ task build() {
 }
 
 task clean() {
+  group = 'Build'
+  description = 'Cleans all submodules'
+
   doLast {
     exec {
       executable "./clean.sh"


### PR DESCRIPTION
Add a `group` allows `./gradlew tasks` to display the `build` and `clean`
tasks. Without the group you have to use `--all` option,
`./gradlew tasks --all`.

  $ ./gradlew tasks

  > Task :tasks

  ------------------------------------------------------------
  Tasks runnable from root project
  ------------------------------------------------------------

  Build tasks
  -----------
  build - Builds all submodules
  clean - Cleans all submodules

  Build Setup tasks
  -----------------
  init - Initializes a new Gradle build.
  wrapper - Generates Gradle wrapper files.

  Help tasks
  ----------
  buildEnvironment - Displays all buildscript dependencies declared in root project 'PerspectiveSuite'.
  components - Displays the components produced by root project 'PerspectiveSuite'. [incubating]
  dependencies - Displays all dependencies declared in root project 'PerspectiveSuite'.
  dependencyInsight - Displays the insight into a specific dependency in root project 'PerspectiveSuite'.
  dependentComponents - Displays the dependent components of components in root project 'PerspectiveSuite'. [incubating]
  help - Displays a help message.
  model - Displays the configuration model of root project 'PerspectiveSuite'. [incubating]
  projects - Displays the sub-projects of root project 'PerspectiveSuite'.
  properties - Displays the properties of root project 'PerspectiveSuite'.
  tasks - Displays the tasks runnable from root project 'PerspectiveSuite'.

  To see all tasks and more detail, run gradlew tasks --all

  To see more detail about a task, run gradlew help --task <task>

  BUILD SUCCESSFUL in 464ms